### PR TITLE
Fix isIndex for primary keys

### DIFF
--- a/pkg/e2db/README.md
+++ b/pkg/e2db/README.md
@@ -118,7 +118,7 @@ where an index key/value exists for every item that is indexed. In other words, 
 Creating a table object can be achieved by passing in a concrete type for the defined table:
 
 ```go
-users := db.Table(User{})
+users := db.Table(new(User))
 ```
 
 This can now be used as a reference to refer to that table. Under the hood, e2db is using this to lazily store and check any subsequent operations to match an existing schema (stored in the table metadata) with the one passed in. Checking this schema ensures that a table schema other than one already defined for a table will result in an error.

--- a/pkg/e2db/model.go
+++ b/pkg/e2db/model.go
@@ -21,7 +21,7 @@ type FieldDef struct {
 }
 
 func (f *FieldDef) isIndex() bool {
-	return f.hasTag("index", "unique")
+	return f.isPrimaryKey() || f.hasTag("index", "unique")
 }
 
 func (f *FieldDef) hasTag(tags ...string) bool {


### PR DESCRIPTION
Checking metadata for indexes in the ModelDef failed when referring to primary keys. This adds a check for primary key as well since they are inherently indexed.