### PR TITLE
pkg/e2db: fix Delete bug on primary index

### DIFF
--- a/pkg/e2db/db_test.go
+++ b/pkg/e2db/db_test.go
@@ -175,6 +175,26 @@ func TestCount(t *testing.T) {
 	}
 }
 
+func TestCountPrimaryIndex(t *testing.T) {
+	resetTable(t)
+	roles := db.Table(&Role{})
+	n, err := roles.Count("ID", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("expected count 1, received %d", n)
+	}
+
+	n, err = roles.Count("ID", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("expected count 0, received %d", n)
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	resetTable(t)
 	roles := db.Table(&Role{})

--- a/pkg/e2db/db_test.go
+++ b/pkg/e2db/db_test.go
@@ -197,3 +197,71 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("e2db: after Update differs: (-want +got)\n%s", diff)
 	}
 }
+
+func TestDeletePrimaryIndex(t *testing.T) {
+	resetTable(t)
+	roles := db.Table(&Role{})
+
+	n, err := roles.Delete("ID", 10)
+	if err != nil {
+		t.Fatalf("unexpected error deleting non-existant key: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected zero rows affected when deleting non-existant key, got %d", n)
+	}
+
+	n, err = roles.Delete("ID", 1)
+	if err != nil {
+		t.Fatalf("unexpected error deleting by ID: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected one row affected when deleting by ID, got %d", n)
+	}
+
+	var r []*Role
+	if err := roles.All(&r); err != nil {
+		t.Fatal(err)
+	}
+	expected := []*Role{
+		{ID: 2, Name: "admin", Description: "administrator"},
+		{ID: 3, Name: "superadmin", Description: "administrator"},
+		{ID: 4, Name: "smoot", Description: "administrator"},
+	}
+	if diff := cmp.Diff(expected, r); diff != "" {
+		t.Errorf("e2db: after Update differs: (-want +got)\n%s", diff)
+	}
+}
+
+func TestDeleteSecondaryIndex(t *testing.T) {
+	resetTable(t)
+	roles := db.Table(&Role{})
+
+	n, err := roles.Delete("Name", "n/a")
+	if err != nil {
+		t.Fatalf("unexpected error deleting non-existant key: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected zero rows affected when deleting non-existant key, got %d", n)
+	}
+
+	n, err = roles.Delete("Name", "smoot")
+	if err != nil {
+		t.Fatalf("unexpected error deleting by Name: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected one row affected when deleting by Name, got %d", n)
+	}
+
+	var r []*Role
+	if err := roles.All(&r); err != nil {
+		t.Fatal(err)
+	}
+	expected := []*Role{
+		{ID: 1, Name: "user", Description: "user"},
+		{ID: 2, Name: "admin", Description: "administrator"},
+		{ID: 3, Name: "superadmin", Description: "administrator"},
+	}
+	if diff := cmp.Diff(expected, r); diff != "" {
+		t.Errorf("e2db: after Update differs: (-want +got)\n%s", diff)
+	}
+}

--- a/pkg/e2db/model.go
+++ b/pkg/e2db/model.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/criticalstack/e2d/pkg/e2db/key"
 	"github.com/pkg/errors"
 )
 
@@ -64,6 +65,17 @@ func (f *FieldDef) Type() IndexType {
 		return UniqueIndex
 	default:
 		return NoIndex
+	}
+}
+
+func (f *FieldDef) indexKey(tableName string, value string) (string, error) {
+	switch f.Type() {
+	case PrimaryKey:
+		return key.ID(tableName, value), nil
+	case SecondaryIndex, UniqueIndex:
+		return key.Indexes(tableName, f.Name, value), nil
+	default:
+		return "", errors.Wrap(ErrNotIndexed, f.Name)
 	}
 }
 

--- a/pkg/e2db/query.go
+++ b/pkg/e2db/query.go
@@ -223,10 +223,11 @@ func (q *query) Count(fieldName string, data interface{}) (int64, error) {
 	if !ok {
 		return 0, errors.Wrap(ErrInvalidField, fieldName)
 	}
-	if !f.isIndex() {
-		return 0, errors.Wrap(ErrNotIndexed, fieldName)
+	k, err := f.indexKey(q.t.meta.Name, toString(data))
+	if err != nil {
+		return 0, err
 	}
-	return q.t.db.client.Count(key.Indexes(q.t.meta.Name, f.Name, toString(data)))
+	return q.t.db.client.Count(k)
 }
 
 func (q *query) Find(fieldName string, data interface{}, to interface{}) error {


### PR DESCRIPTION
Fixed a branch in the Delete logic when the key is a primary index.
Return the rows affected in this case. In the secondary index case,
increment rows affected by 1 for each k/v pair, rather than 1 per key
and 1 per value. Do not return an error if the secondary index key does
not exist, to match the primary index deletion behavior.

**NOTE**: Regarding the rows affected change, feel free to revert if that was not the intended behavior. When I wrote the test for it the expected result did not match, which is what prompted the change. Also, feel free to remove the check for the "key not found" error - though I think it might be most intuitive to add a check for `resp.Deleted == 0` in the primary index case so an error can be returned from that path as well.

**edit**: Also adjusted the behavior of `Count` when used on a primary index - it had the same issue of building the key path as if it were a secondary index. I added a helper function to make it a little cleaner, but I don't know if that will be useful anywhere else.