### PR TITLE
Add batch operations for transaction atomicity

### DIFF
--- a/pkg/e2db/db_test.go
+++ b/pkg/e2db/db_test.go
@@ -261,14 +261,15 @@ func TestDeleteSecondaryIndex(t *testing.T) {
 		t.Fatalf("unexpected error deleting non-existant key: %v", err)
 	}
 	if n != 0 {
-		t.Fatalf("expected zero rows affected when deleting non-existant key, got %d", n)
+		t.Fatalf("expected zero rows affected when deleting non-existent key, got %d", n)
 	}
 
 	n, err = roles.Delete("Name", "smoot")
 	if err != nil {
 		t.Fatalf("unexpected error deleting by Name: %v", err)
 	}
-	if n != 1 {
+	// NOTE(chris): includes value and index
+	if n != 2 {
 		t.Fatalf("expected one row affected when deleting by Name, got %d", n)
 	}
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -15,7 +15,7 @@ var (
 		NewEncoder(NewDefaultEncoderConfig()),
 		zapcore.AddSync(os.Stderr),
 		level,
-	))
+	), zap.AddCaller())
 )
 
 // NewLogger creates a new child logger with the provided namespace.
@@ -28,7 +28,7 @@ func NewLogger(ns string) *zap.Logger {
 			zapcore.AddSync(os.Stderr),
 			level,
 		)
-	}))
+	}), zap.AddCaller())
 }
 
 // NewLogger creates a new child logger with the provided namespace and level.


### PR DESCRIPTION
Fixes #5.

This ensures that in situations where a node spontaneously dies in the middle of an e2db transaction, it won't leave an inconsistent state in the database since all logical operations are combined into a single batch operation.