### PR TITLE
Add manager.Config option for etcd log level

### DIFF
--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func init() {
@@ -89,6 +90,9 @@ type Config struct {
 
 	// configures authentication/transport security within the etcd cluster
 	PeerSecurity client.SecurityConfig
+
+	// configures the level of the logger used by etcd
+	EtcdLogLevel zapcore.Level
 
 	discovery.PeerProvider
 	snapshot.SnapshotProvider

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -51,6 +51,7 @@ func New(cfg *Config) (*Manager, error) {
 			RequiredClusterSize: cfg.RequiredClusterSize,
 			ClientSecurity:      cfg.ClientSecurity,
 			PeerSecurity:        cfg.PeerSecurity,
+			EtcdLogLevel:        cfg.EtcdLogLevel,
 			Debug:               cfg.Debug,
 			EnableLocalListener: true,
 		}),

--- a/pkg/manager/server.go
+++ b/pkg/manager/server.go
@@ -53,6 +53,9 @@ type serverConfig struct {
 	// add a local client listener (i.e. 127.0.0.1)
 	EnableLocalListener bool
 
+	// configures the level of the logger used by etcd
+	EtcdLogLevel zapcore.Level
+
 	Debug bool
 }
 
@@ -169,7 +172,7 @@ func (s *server) startEtcd(state string, peers []*Peer) error {
 	cfg.Logger = "zap"
 	cfg.Debug = s.cfg.Debug
 	cfg.ZapLoggerBuilder = func(c *embed.Config) error {
-		l := log.NewLoggerWithLevel("etcd", zapcore.InfoLevel)
+		l := log.NewLoggerWithLevel("etcd", s.cfg.EtcdLogLevel)
 		return embed.NewZapCoreLoggerBuilder(l, l.Core(), zapcore.AddSync(os.Stderr))(c)
 	}
 	cfg.AutoCompactionMode = embed.CompactorModePeriodic


### PR DESCRIPTION
Added a new field to the manager.Config struct that is used during the
creation of the etcd zap logger. The zero-value default level is info.