### PR TITLE
e2db: iterate indexes while deleting

### DIFF
--- a/pkg/e2db/db_test.go
+++ b/pkg/e2db/db_test.go
@@ -31,6 +31,7 @@ func init() {
 		RequiredClusterSize: 1,
 		HealthCheckInterval: 1 * time.Second,
 		HealthCheckTimeout:  5 * time.Second,
+		EtcdLogLevel:        zapcore.WarnLevel,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -214,75 +215,6 @@ func TestUpdate(t *testing.T) {
 	}
 	expected := &Role{ID: 1, Name: "user", Description: "updated user"}
 	if diff := cmp.Diff(expected, &r); diff != "" {
-		t.Errorf("e2db: after Update differs: (-want +got)\n%s", diff)
-	}
-}
-
-func TestDeletePrimaryIndex(t *testing.T) {
-	resetTable(t)
-	roles := db.Table(&Role{})
-
-	n, err := roles.Delete("ID", 10)
-	if err != nil {
-		t.Fatalf("unexpected error deleting non-existant key: %v", err)
-	}
-	if n != 0 {
-		t.Fatalf("expected zero rows affected when deleting non-existant key, got %d", n)
-	}
-
-	n, err = roles.Delete("ID", 1)
-	if err != nil {
-		t.Fatalf("unexpected error deleting by ID: %v", err)
-	}
-	if n != 1 {
-		t.Fatalf("expected one row affected when deleting by ID, got %d", n)
-	}
-
-	var r []*Role
-	if err := roles.All(&r); err != nil {
-		t.Fatal(err)
-	}
-	expected := []*Role{
-		{ID: 2, Name: "admin", Description: "administrator"},
-		{ID: 3, Name: "superadmin", Description: "administrator"},
-		{ID: 4, Name: "smoot", Description: "administrator"},
-	}
-	if diff := cmp.Diff(expected, r); diff != "" {
-		t.Errorf("e2db: after Update differs: (-want +got)\n%s", diff)
-	}
-}
-
-func TestDeleteSecondaryIndex(t *testing.T) {
-	resetTable(t)
-	roles := db.Table(&Role{})
-
-	n, err := roles.Delete("Name", "n/a")
-	if err != nil {
-		t.Fatalf("unexpected error deleting non-existant key: %v", err)
-	}
-	if n != 0 {
-		t.Fatalf("expected zero rows affected when deleting non-existent key, got %d", n)
-	}
-
-	n, err = roles.Delete("Name", "smoot")
-	if err != nil {
-		t.Fatalf("unexpected error deleting by Name: %v", err)
-	}
-	// NOTE(chris): includes value and index
-	if n != 2 {
-		t.Fatalf("expected one row affected when deleting by Name, got %d", n)
-	}
-
-	var r []*Role
-	if err := roles.All(&r); err != nil {
-		t.Fatal(err)
-	}
-	expected := []*Role{
-		{ID: 1, Name: "user", Description: "user"},
-		{ID: 2, Name: "admin", Description: "administrator"},
-		{ID: 3, Name: "superadmin", Description: "administrator"},
-	}
-	if diff := cmp.Diff(expected, r); diff != "" {
 		t.Errorf("e2db: after Update differs: (-want +got)\n%s", diff)
 	}
 }

--- a/pkg/e2db/key/key.go
+++ b/pkg/e2db/key/key.go
@@ -27,7 +27,7 @@ func ID(model, key string) string {
 }
 
 func Table(model string) string {
-	return join(model)
+	return join(model) + "/"
 }
 
 func TableDef(model string) string {

--- a/pkg/e2db/model.go
+++ b/pkg/e2db/model.go
@@ -82,6 +82,8 @@ func (f *FieldDef) indexKey(tableName string, value string) (string, error) {
 type ModelDef struct {
 	Name   string
 	Fields map[string]*FieldDef
+
+	t reflect.Type
 }
 
 func NewModelDef(t reflect.Type) *ModelDef {
@@ -94,6 +96,7 @@ func NewModelDef(t reflect.Type) *ModelDef {
 	m := &ModelDef{
 		Name:   t.Name(),
 		Fields: make(map[string]*FieldDef),
+		t:      t,
 	}
 	for i := 0; i < t.NumField(); i++ {
 		ft := t.Field(i)
@@ -114,6 +117,14 @@ func NewModelDef(t reflect.Type) *ModelDef {
 		}
 	}
 	return m
+}
+
+func (m *ModelDef) New() *reflect.Value {
+	if m.t == nil {
+		return nil
+	}
+	v := reflect.New(m.t)
+	return &v
 }
 
 type Field struct {

--- a/pkg/e2db/query.go
+++ b/pkg/e2db/query.go
@@ -255,6 +255,14 @@ func (q *query) Find(fieldName string, data interface{}, to interface{}) error {
 	}
 	k := toString(data)
 	if v.Type().Kind() == reflect.Slice {
+		if f.isPrimaryKey() {
+			item := reflect.New(v.Type().Elem())
+			if err := q.findOneByPrimaryKey(key.ID(q.t.meta.Name, k), reflect.Indirect(item)); err != nil {
+				return err
+			}
+			v.Set(reflect.Append(v, item.Elem()))
+			return nil
+		}
 		return q.findManyByIndex(key.Indexes(q.t.meta.Name, f.Name, k), v)
 	}
 	switch f.Type() {

--- a/pkg/e2db/tx_test.go
+++ b/pkg/e2db/tx_test.go
@@ -3,6 +3,7 @@ package e2db
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 )
 
@@ -22,5 +23,98 @@ func TestTxInsert(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestTxDelete(t *testing.T) {
+	cases := []struct {
+		name   string
+		field  string
+		value  interface{}
+		filter func(*Role) bool
+		n      int64
+		err    error
+	}{
+		{
+			name:   "delete absent key",
+			field:  "ID",
+			value:  20,
+			filter: func(r *Role) bool { return r.ID == 20 },
+		},
+		{
+			name:   "delete primary key",
+			field:  "ID",
+			value:  3,
+			n:      1,
+			filter: func(r *Role) bool { return r.ID == 3 },
+		},
+		{
+			name:   "delete secondary index",
+			field:  "Description",
+			value:  "administrator",
+			n:      3,
+			filter: func(r *Role) bool { return r.Description == "administrator" },
+		},
+		{
+			name:   "delete unique index",
+			field:  "Name",
+			value:  "smoot",
+			n:      1,
+			filter: func(r *Role) bool { return r.Name == "smoot" },
+		},
+		{
+			name:   "delete secondary index not found",
+			field:  "Description",
+			value:  "dinosaur",
+			filter: func(r *Role) bool { return r.Description == "dinosaur" },
+		},
+		{
+			name:   "delete unique index not found",
+			field:  "Name",
+			value:  "smootest",
+			filter: func(r *Role) bool { return r.Name == "smootest" },
+		},
+		{
+			name:  "delete non-index",
+			field: "NotIndexed",
+			value: "something",
+			err:   ErrNotIndexed,
+		},
+		// TODO(ktravis): make field/value a map to test multiple deletions in sequence
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resetTable(t)
+			roles := db.Table(&Role{})
+			n, err := roles.Delete(c.field, c.value)
+			if errors.Cause(err) != c.err {
+				t.Fatalf("expected error %v, got %v", c.err, err)
+			}
+			if c.err == nil {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				return
+			}
+			if n != c.n {
+				t.Fatalf("expected delete count %d, got %d", c.n, n)
+			}
+
+			expected := append([]*Role{}, newRoles...)
+			for i := 0; i < len(expected); i++ {
+				if c.filter(expected[i]) {
+					expected = append(expected[:i], expected[i+1:]...)
+					i--
+				}
+			}
+			var result []*Role
+			if err := roles.All(&result); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(expected, result); diff != "" {
+				t.Fatal("results did not match expected", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Scan object while it is being deleted to delete entries in
secondary/unique indexes for its current values. This requires that the
object be retrieved from storage prior to deletion.