### PR TITLE
Use lower TTL for db lock session

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -165,7 +165,10 @@ func (c *Client) Prefix(key string) ([]*mvccpb.KeyValue, error) {
 }
 
 func (c *Client) Lock(key string, timeout time.Duration) (context.CancelFunc, error) {
-	session, err := concurrency.NewSession(c.Client)
+	// The session uses a low TTL to ensure that keep alives are sent more
+	// frequently than the default. This ensures that a failed node with
+	// initiated locks will not cause a deadlock for more than 5 seconds.
+	session, err := concurrency.NewSession(c.Client, concurrency.WithTTL(5))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This applies to all locks initiate by the client package, but is mostly
set to ensure that e2db is deadlocked for a shorter period of time in
the case where a node completely fails while still holding onto a lock.