### PR TITLE
e2db: promote nested struct fields when embedded

### DIFF
--- a/pkg/e2db/model.go
+++ b/pkg/e2db/model.go
@@ -80,30 +80,43 @@ func (f *FieldDef) indexKey(tableName string, value string) (string, error) {
 	}
 }
 
-type ModelDef struct {
-	Name   string
-	Fields map[string]*FieldDef
-
-	t reflect.Type
+func typeIsEqual(t1, t2 reflect.Type) bool {
+	if t1.Kind() == reflect.Ptr {
+		t1 = t1.Elem()
+	}
+	if t2.Kind() == reflect.Ptr {
+		t2 = t2.Elem()
+	}
+	return t1 == t2
 }
 
-func readFields(t reflect.Type) map[string]*FieldDef {
+// readStructFields constructs a map of FieldDefs from the provided struct
+// type. The function only recurses into struct types when being embedded and
+// will promote fields from the embedded type to the embedding type when there
+// isn't a naming conflict.
+func readStructFields(t reflect.Type) map[string]*FieldDef {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		panic("must provide struct type")
 	}
 	if t.NumField() == 0 {
 		panic("must have at least 1 struct field")
 	}
 	fields := make(map[string]*FieldDef)
-	anon := make([]reflect.StructField, 0)
+	embeddedFields := make([]reflect.StructField, 0)
 	for i := 0; i < t.NumField(); i++ {
-		ft := t.Field(i)
-		if ft.Anonymous && ft.Type.Kind() != reflect.Interface {
-			anon = append(anon, ft)
+		f := t.Field(i)
+		if typeIsEqual(f.Type, t) {
+			continue
+		}
+		if f.Anonymous && f.Type.Kind() != reflect.Interface {
+			embeddedFields = append(embeddedFields, f)
 			continue
 		}
 		tags := make([]*Tag, 0)
-		if tagValue, ok := ft.Tag.Lookup("e2db"); ok {
+		if tagValue, ok := f.Tag.Lookup("e2db"); ok {
 			for _, t := range strings.Split(tagValue, ",") {
 				parts := strings.SplitN(t, "=", 2)
 				if len(parts) == 2 {
@@ -113,39 +126,62 @@ func readFields(t reflect.Type) map[string]*FieldDef {
 				}
 			}
 		}
-		fields[ft.Name] = &FieldDef{
-			Name: ft.Name,
+		fields[f.Name] = &FieldDef{
+			Name: f.Name,
 			Tags: tags,
 		}
 	}
 
-	// Process anonymous/embedded struct fields in a second pass to allow parent
-	// fields to supersede the embedded struct fields.
-	for _, ft := range anon {
-		for n, f := range readFields(ft.Type) {
-			if _, ok := fields[n]; ok {
-				// Field is superseded in parent struct, ignore.
+	// promote any embedded struct fields
+	for _, f := range embeddedFields {
+		ft := f.Type
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		switch ft.Kind() {
+		case reflect.Struct:
+			for n, f := range readStructFields(ft) {
+				if _, ok := fields[n]; ok {
+					continue
+				}
+				if _, ok := t.FieldByName(n); !ok {
+					panic(fmt.Sprintf("struct field in type %v is ambiguous: %q", t, n))
+				}
+				fields[n] = f
+			}
+		default:
+			if _, ok := fields[f.Name]; ok {
 				continue
 			}
-			if _, ok := t.FieldByName(n); !ok {
-				panic(fmt.Sprintf("struct field in type %v is ambiguous: %q", t, n))
+			fields[f.Name] = &FieldDef{
+				Name: f.Name,
+				Tags: make([]*Tag, 0),
 			}
-			fields[n] = f
 		}
 	}
 	return fields
+}
+
+type ModelDef struct {
+	Name   string
+	Fields map[string]*FieldDef
+
+	t reflect.Type
 }
 
 func NewModelDef(t reflect.Type) *ModelDef {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
+	if t.Kind() != reflect.Struct {
+		panic("must provide struct type")
+	}
 	if t.NumField() == 0 {
 		panic("must have at least 1 struct field")
 	}
 	m := &ModelDef{
 		Name:   t.Name(),
-		Fields: readFields(t),
+		Fields: readStructFields(t),
 		t:      t,
 	}
 	return m

--- a/pkg/e2db/model_test.go
+++ b/pkg/e2db/model_test.go
@@ -1,0 +1,258 @@
+package e2db_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/criticalstack/e2d/pkg/e2db"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func field(name string, tags ...string) *e2db.FieldDef {
+	f := &e2db.FieldDef{
+		Name: name,
+		Tags: []*e2db.Tag{},
+	}
+	for _, t := range tags {
+		f.Tags = append(f.Tags, &e2db.Tag{Name: t})
+	}
+	return f
+}
+
+func fieldMap(ff ...*e2db.FieldDef) map[string]*e2db.FieldDef {
+	m := make(map[string]*e2db.FieldDef)
+	for _, f := range ff {
+		m[f.Name] = f
+	}
+	return m
+}
+
+func TestNewModelDef(t *testing.T) {
+	cases := []struct {
+		name        string
+		model       func() reflect.Type
+		expected    *e2db.ModelDef
+		expectPanic bool
+	}{
+		{
+			name: "simple",
+			model: func() reflect.Type {
+				type testModel struct {
+					ID          string `e2db:"id"`
+					Name        string `e2db:"unique"`
+					Age         int
+					favoriteNum int
+				}
+				return reflect.TypeOf(new(testModel))
+			},
+			expected: &e2db.ModelDef{
+				Name: "testModel",
+				Fields: fieldMap(
+					field("Age"),
+					field("ID", "id"),
+					field("Name", "unique"),
+					field("favoriteNum"),
+				),
+			},
+		},
+		{
+			name: "nested",
+			model: func() reflect.Type {
+				type nest struct {
+					Name string `e2db:"unique"`
+				}
+				type testModelNested struct {
+					ID string `e2db:"id"`
+					nest
+					Age         int
+					favoriteNum int
+				}
+				return reflect.TypeOf(new(testModelNested))
+			},
+			expected: &e2db.ModelDef{
+				Name: "testModelNested",
+				Fields: fieldMap(
+					field("Age"),
+					field("ID", "id"),
+					field("Name", "unique"),
+					field("favoriteNum"),
+				),
+			},
+		},
+		{
+			name: "nested struct pointer",
+			model: func() reflect.Type {
+				type nest struct {
+					Name string `e2db:"unique"`
+				}
+				type testModelNested struct {
+					ID string `e2db:"id"`
+					*nest
+					Age         int
+					favoriteNum int
+				}
+				return reflect.TypeOf(new(testModelNested))
+			},
+			expected: &e2db.ModelDef{
+				Name: "testModelNested",
+				Fields: fieldMap(
+					field("Age"),
+					field("ID", "id"),
+					field("Name", "unique"),
+					field("favoriteNum"),
+				),
+			},
+		},
+		{
+			name: "nested interface",
+			model: func() reflect.Type {
+				type nest interface {
+					Name() string
+				}
+				type testModel struct {
+					ID string `e2db:"id"`
+					nest
+					Age         int
+					favoriteNum int
+				}
+				return reflect.TypeOf(new(testModel))
+			},
+			expected: &e2db.ModelDef{
+				Name: "testModel",
+				Fields: fieldMap(
+					field("Age"),
+					// embedded interface is treated as opaque value
+					field("nest"),
+					field("ID", "id"),
+					field("favoriteNum"),
+				),
+			},
+		},
+		{
+			name: "nesting preempted",
+			model: func() reflect.Type {
+				type nest struct {
+					Name  string `e2db:"unique"`
+					Other float64
+				}
+				type testModel struct {
+					ID string `e2db:"id"`
+					nest
+					Name        string
+					Age         int
+					favoriteNum int
+				}
+				return reflect.TypeOf(new(testModel))
+			},
+			expected: &e2db.ModelDef{
+				Name: "testModel",
+				Fields: fieldMap(
+					field("Age"),
+					field("ID", "id"),
+					// no tag on this one, because the parent struct preempts the nest
+					field("Name"),
+					field("favoriteNum"),
+					field("Other"),
+				),
+			},
+		},
+		{
+			name: "ambiguous",
+			model: func() reflect.Type {
+				type nestA struct {
+					Name string `e2db:"unique"`
+				}
+				type nestB struct {
+					Name string `e2db:"index"`
+				}
+				type testModel struct {
+					nestA
+					nestB
+					ID          string `e2db:"id"`
+					Age         int
+					favoriteNum int
+				}
+				return reflect.TypeOf(new(testModel))
+			},
+			expectPanic: true,
+		},
+		{
+			name: "ambiguity resolved",
+			model: func() reflect.Type {
+				type nestA struct {
+					Name string `e2db:"unique"`
+				}
+				type nestB struct {
+					Name  string `e2db:"index"`
+					Other float64
+				}
+				type testModel struct {
+					nestA
+					nestB
+					ID          string `e2db:"id"`
+					Name        string
+					Age         int
+					favoriteNum int
+				}
+				return reflect.TypeOf(new(testModel))
+			},
+			expected: &e2db.ModelDef{
+				Name: "testModel",
+				Fields: fieldMap(
+					field("Age"),
+					field("ID", "id"),
+					// ambiguity is resolved by parent override
+					field("Name"),
+					field("favoriteNum"),
+					field("Other"),
+				),
+			},
+		},
+		{
+			name: "recursive",
+			model: func() reflect.Type {
+				type nestInner struct {
+					Name string `e2db:"unique"`
+				}
+				type nestOuter struct {
+					nestInner
+					Other float64
+				}
+				type testModel struct {
+					nestOuter
+					ID          string `e2db:"id"`
+					Age         int
+					favoriteNum int
+				}
+				return reflect.TypeOf(new(testModel))
+			},
+			expected: &e2db.ModelDef{
+				Name: "testModel",
+				Fields: fieldMap(
+					field("Age"),
+					field("ID", "id"),
+					field("Name", "unique"),
+					field("favoriteNum"),
+					field("Other"),
+				),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.expectPanic {
+				defer func() {
+					if x := recover(); x == nil {
+						t.Fatal("expected NewModelDef to panic")
+					}
+				}()
+			}
+			def := e2db.NewModelDef(c.model())
+			if diff := cmp.Diff(c.expected, def, cmpopts.IgnoreUnexported(e2db.ModelDef{})); diff != "" {
+				t.Fatalf("ModelDef did not match expected: %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This represents a change in behavior for e2db's ModelDef - previously
an embedded struct or struct pointer would represent a single field,
this change instead promotes the (non-conflicting) fields of the
embedded struct type into the ModelDef of the parent. If there is an
ambiguity in the nested struct fields that would be promoted (as
determined by reflect.Type.FieldByName), NewModelDef panics.