### PR TITLE
prevent invalid peer addr from being added to bootstrap addrs

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -8,6 +8,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// IsRoutableIP checks that the passed string can be parsed in to a valid IPv4
+// address, and that it is not a loopback or unspecified address that would not be
+// reachable outside of that host device.
+func IsRoutableIPv4(s string) bool {
+	if ip := net.ParseIP(s); ip.To4() != nil && !ip.IsLoopback() && !ip.IsUnspecified() {
+		return true
+	}
+	return false
+}
+
 // DetectHostIPv4 attempts to determine the host IPv4 address by finding the
 // first non-loopback device with an assigned IPv4 address.
 func DetectHostIPv4() (string, error) {

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -1,0 +1,32 @@
+package netutil
+
+import "testing"
+
+func TestIsRoutableIPv4(t *testing.T) {
+	tests := []struct {
+		s string
+		want bool
+	}{
+		{
+			"",
+			false,
+		},
+		{
+			"0.0.0.0",
+			false,
+		},
+		{
+			"127.0.0.1",
+			false,
+		},
+		{
+			"10.100.100.100",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		if got := IsRoutableIPv4(tt.s); got != tt.want {
+			t.Errorf("IsRoutableIPv4(%s) = %v, want %v", tt.s, got, tt.want)
+		}
+	}
+}

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/s3manager"
+	"github.com/criticalstack/e2d/pkg/netutil"
 )
 
 type Config struct {
@@ -77,6 +78,9 @@ func (c *Client) GetAddrs(ctx context.Context) ([]string, error) {
 		addr, err := c.describeInstanceIPAddress(ctx, i)
 		if err != nil {
 			return nil, err
+		}
+		if !netutil.IsRoutableIPv4(addr) {
+			continue
 		}
 		addrs = append(addrs, addr)
 	}

--- a/pkg/provider/digitalocean/client.go
+++ b/pkg/provider/digitalocean/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/criticalstack/e2d/pkg/netutil"
 	meta "github.com/digitalocean/go-metadata"
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
@@ -51,6 +52,9 @@ func NewClient(cfg *Config) (*Client, error) {
 
 func (c *Client) GetAddrs(ctx context.Context) ([]string, error) {
 	metadata, err := meta.NewClient().Metadata()
+	if err != nil {
+		return nil, err
+	}
 	filter := ""
 	for _, t := range metadata.Tags {
 		if strings.HasPrefix(t, tagPrefix) {
@@ -69,6 +73,9 @@ func (c *Client) GetAddrs(ctx context.Context) ([]string, error) {
 		addr, err := d.PrivateIPv4()
 		if err != nil {
 			return nil, err
+		}
+		if !netutil.IsRoutableIPv4(addr) {
+			continue
 		}
 		addrs = append(addrs, addr)
 	}


### PR DESCRIPTION
e2d failed to initialize on a node where it didn't get any peer metadata from the cloud provider:

```
...
Started e2d.
L=DEBUG M="cloud provided addresses: []"
L=DEBUG M="bootstrap addrs: [:7980]"
L=DEBUG M="cannot read existing data-dir" error="open /var/lib/etcd/member/snap/db: no such file or directory"
L=DEBUG M="attempting to join gossip network ..." bootstrap-addrs=127.0.0.1:7980
...
```

it was correctly configured via `/var/lib/e2d/config` with `E2D_REQUIRED_CLUSTER_SIZE=3`.

on this node, restarting the service with no additional config changes brought e2d right up. this make me think that the process should have crashed out for the process manager to restart due to bad state (due to eventual consistency issues with the provider).

as far is i can tell, when required-cluster-size > 1, the baddr slice size should always be 1 less than the cluster size the [second time we check it](https://github.com/criticalstack/e2d/blob/0d4b6c85591f7f78ff9f21c084ae4b42591daf5b/cmd/e2d/app/run.go#L65) after we poll the provider, and if it's not we should crash out and let the manager restart us. this should allow us to recover from eventual consistency delays.