### PR TITLE
ship x86_64.deb

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,9 @@ pipeline:
       event:
         - tag
     image: golang:latest
-    secrets: [github_token]
+    secrets: 
+      - github_token
+      - packagecloud_token
     commands:
       - curl -sL https://git.io/goreleaser | bash
+      - curl -F "package[distro_version_id]=190" -F "package[package_file]=@$(ls dist/e2d_*_x86_64.deb)" https://$PKGCLOUD:@packagecloud.io/api/v1/repos/criticalstack/public/packages.json

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,32 +28,27 @@ archives:
     386: i386
     amd64: x86_64
 nfpms:
-  - name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    homepage:  https://github.com/criticalstack/e2d
-    description: Cloud-native etcd management
-    maintainer: criticalstack <dev@criticalstack.com>
-    license: Apache-2.0
-    vendor: criticalstack
-    bindir: "/usr/local/bin"
-    formats:
-    - deb
-    - rpm
-    conflicts:
-    - etcd
-    empty_folders:
-    - /etc/systemd/system/e2d.service.d
-    - /var/lib/etcd
-    files: 
-      deploy/e2d.service: /etc/systemd/system/e2d.service
-    config_files:
-      deploy/e2d.conf: /etc/e2d.conf
-    overrides:
-      deb:
-        replacements:
-          amd64: x86_64
-      rpm:
-        replacements:
-          amd64: x86_64
+- name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  homepage:  https://github.com/criticalstack/e2d
+  description: Cloud-native etcd management
+  maintainer: criticalstack <dev@criticalstack.com>
+  license: Apache-2.0
+  vendor: criticalstack
+  bindir: "/usr/local/bin"
+  replacements:
+    amd64: x86_64
+  formats:
+  - deb
+  - rpm
+  conflicts:
+  - etcd
+  empty_folders:
+  - /etc/systemd/system/e2d.service.d
+  - /var/lib/etcd
+  files: 
+    deploy/e2d.service: /etc/systemd/system/e2d.service
+  config_files:
+    deploy/e2d.conf: /etc/e2d.conf
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
- fix whitespace in nfpm config
- fix name of packages to include version
- ship the 64 bit deb to packagecloud for ubuntu bionic (190)
  - uploading rpms seems to be broken at the moment