### PR TITLE
Ensure tag belongs to EC2 instance

### DIFF
--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -114,9 +114,9 @@ func (c *Client) GetAddressesByTag(ctx context.Context, kvs map[string]string) (
 		Filters: filters,
 	}, func(page *ec2.DescribeTagsOutput, lastPage bool) bool {
 		for _, tag := range page.Tags {
-			//if tag.ResourceType != "ec2" {
-			//continue
-			//}
+			if aws.StringValue(tag.ResourceType) != ec2.ResourceTypeInstance {
+				continue
+			}
 			instances = append(instances, aws.StringValue(tag.ResourceId))
 		}
 		return !lastPage


### PR DESCRIPTION
Without filtering tags by resource type ec2, e2d can discover other aws resources like volumes through peer discovery. This causes issue #34 and will cause e2d to fail to startup.