### PR TITLE
Implement default s3 path when only bucket provided for etcd snapshots

### DIFF
--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -76,7 +76,7 @@ func ParseSnapshotBackupURL(s string) (*URL, error) {
 		return &URL{
 			Type:   S3Type,
 			Bucket: u.Host,
-			Path:   u.Path,
+			Path:   strings.TrimPrefix(u.Path, "/"),
 		}, nil
 	case "http", "https":
 		if strings.Contains(u.Host, "digitaloceanspaces") {

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -70,6 +70,9 @@ func ParseSnapshotBackupURL(s string) (*URL, error) {
 			Path: filepath.Join(u.Host, u.Path),
 		}, nil
 	case "s3":
+		if u.Path == "" {
+			u.Path = "etcd.snapshot"
+		}
 		return &URL{
 			Type:   S3Type,
 			Bucket: u.Host,

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -43,7 +43,17 @@ func TestParseSnapshotBackupURL(t *testing.T) {
 		{
 			name:     "s3",
 			url:      "s3://abc",
-			expected: &URL{Type: S3Type, Bucket: "abc"},
+			expected: &URL{Type: S3Type, Bucket: "abc", Path: "etcd.snapshot"},
+		},
+		{
+			name:     "s3",
+			url:      "s3://abc/snapshot.gz",
+			expected: &URL{Type: S3Type, Bucket: "abc", Path: "snapshot.gz"},
+		},
+		{
+			name:     "s3",
+			url:      "s3://abc/backupdir/snapshot.gz",
+			expected: &URL{Type: S3Type, Bucket: "abc", Path: "backupdir/snapshot.gz"},
 		},
 		{
 			name:     "spaces",


### PR DESCRIPTION
When path is not provided with etcd s3 snapshot options, e2d should still be able to write to the provided bucket with a default filename, in this case I chose `etcd.snapshot`.

fixes #36 
