### PR TITLE
Add chmod on start

### DIFF
--- a/pkg/snapshot/snapshot_file.go
+++ b/pkg/snapshot/snapshot_file.go
@@ -13,7 +13,7 @@ type FileSnapshotter struct {
 }
 
 func NewFileSnapshotter(path string) (*FileSnapshotter, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil && !os.IsExist(err) {
 		return nil, errors.Wrapf(err, "cannot create snapshot directory: %#v", filepath.Dir(path))
 	}
 	return &FileSnapshotter{file: path}, nil


### PR DESCRIPTION
Etcd 3.4.9 introduced a check on the data directory permissions that require 0700. Since this causes the server to not come up we will attempt to change the perms.